### PR TITLE
SEO改善: ブログ詳細ページのメタデータ最適化

### DIFF
--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -111,11 +111,12 @@ export const generateMetadata = async (props: PageProps<{ slug: string }>): Prom
 
   const title = postTitle;
   // 記事の本文からdescriptionを生成（HTMLタグを除去し、最初の160文字を使用）
-  const description = body
-    .replace(/<[^>]*>/g, '') // HTMLタグを除去
-    .replace(/\s+/g, ' ') // 連続する空白を一つにまとめる
-    .trim()
-    .slice(0, 160) + (body.replace(/<[^>]*>/g, '').length > 160 ? '...' : '');
+  const description =
+    body
+      .replace(/<[^>]*>/g, "") // HTMLタグを除去
+      .replace(/\s+/g, " ") // 連続する空白を一つにまとめる
+      .trim()
+      .slice(0, 160) + (body.replace(/<[^>]*>/g, "").length > 160 ? "..." : "");
   const url = `${SITE.url}${ROUTE.postDetail(slug)}`;
 
   const image = thumbnail

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -107,7 +107,7 @@ export const generateMetadata = async (props: PageProps<{ slug: string }>): Prom
   const { post } = await fetchData(slug, draftKey);
   if (!post) return {};
 
-  const { title: postTitle, thumbnail, publishedAt, body } = post;
+  const { title: postTitle, thumbnail, publishedAt, updatedAt, body } = post;
 
   const title = postTitle;
   // 記事の本文からdescriptionを生成（HTMLタグを除去し、最初の160文字を使用）
@@ -145,6 +145,7 @@ export const generateMetadata = async (props: PageProps<{ slug: string }>): Prom
       images: [image],
       type: "article",
       publishedTime: publishedAt,
+      modifiedTime: updatedAt,
     },
   };
 };

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -107,10 +107,15 @@ export const generateMetadata = async (props: PageProps<{ slug: string }>): Prom
   const { post } = await fetchData(slug, draftKey);
   if (!post) return {};
 
-  const { title: postTitle, thumbnail, publishedAt } = post;
+  const { title: postTitle, thumbnail, publishedAt, body } = post;
 
   const title = postTitle;
-  const description = SITE.description;
+  // 記事の本文からdescriptionを生成（HTMLタグを除去し、最初の160文字を使用）
+  const description = body
+    .replace(/<[^>]*>/g, '') // HTMLタグを除去
+    .replace(/\s+/g, ' ') // 連続する空白を一つにまとめる
+    .trim()
+    .slice(0, 160) + (body.replace(/<[^>]*>/g, '').length > 160 ? '...' : '');
   const url = `${SITE.url}${ROUTE.postDetail(slug)}`;
 
   const image = thumbnail

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -121,7 +121,7 @@ export const generateMetadata = async (props: PageProps<{ slug: string }>): Prom
   const image = thumbnail
     ? {
         url: thumbnail.url,
-        with: thumbnail.width,
+        width: thumbnail.width,
         height: thumbnail.height,
       }
     : {


### PR DESCRIPTION
## Summary
- 記事固有のdescriptionを本文から生成するよう改善
- Open Graphの画像サイズプロパティのタイポ修正（with→width）
- Open GraphにmodifiedTime（記事更新日時）を追加

## 改善内容

### 1. 記事固有のdescription生成
- サイト共通のdescriptionではなく、記事本文から160文字を抽出
- HTMLタグを除去して適切なdescriptionを自動生成
- SEO向上により検索結果での表示が改善

### 2. Open Graphプロパティの修正
- 画像サイズの`with`を正しい`width`に修正
- 構造化データの正確性を向上

### 3. 記事更新日時の追加
- Open GraphにmodifiedTimeを追加
- 検索エンジンが記事の更新状況を正確に把握可能
- SEO最適化により検索ランキングに貢献

## Test plan
- [ ] `pnpm type-check` でTypeScriptエラーがないことを確認
- [ ] `pnpm check` でコード品質チェックを実行
- [ ] ブログ詳細ページで適切なメタデータが生成されることを確認
- [ ] Open Graphの構造化データが正しく設定されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)